### PR TITLE
Shreyas bhat patch 2

### DIFF
--- a/Chefs in queue (CHFQUEUE).cpp
+++ b/Chefs in queue (CHFQUEUE).cpp
@@ -1,6 +1,7 @@
 #include <bits/stdc++.h>
 #define int long long
 using namespace std;
+
 int MOD = 1e9+7;
 int fearx(int arr[], int n){
     stack<pair<int, int> > s;

--- a/Chefs in queue (CHFQUEUE).cpp
+++ b/Chefs in queue (CHFQUEUE).cpp
@@ -1,8 +1,7 @@
 #include <bits/stdc++.h>
 #define int long long
-#define MOD 1000000007
 using namespace std;
-
+int MOD = 1e9+7;
 int fearx(int arr[], int n){
     stack<pair<int, int> > s;
     int fear = 1;


### PR DESCRIPTION
Debugged for the following error:
prog.cpp: In function ‘long long int fearx(long long int*, long long int)’:
prog.cpp:13:27: error: invalid operands of types ‘long long int’ and ‘double’ to binary ‘operator%’
fear = ((fear)%MOD*(s.top().second-i)%MOD)%MOD;
^
prog.cpp:13:50: error: invalid operands of types ‘long long int’ and ‘double’ to binary ‘operator%’
fear = ((fear)%MOD*(s.top().second-i)%MOD)%MOD;